### PR TITLE
Drop support for old Node.js versions

### DIFF
--- a/.changeset/drop-old-node.md
+++ b/.changeset/drop-old-node.md
@@ -1,0 +1,5 @@
+---
+"stylelint-config-html": major
+---
+
+Drop support for old Node.js versions. Node.js `^22.12 || >=24` is now required.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,8 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.202.5/containers/javascript-node/.devcontainer/base.Dockerfile
+# See here for image contents: https://github.com/devcontainers/images/tree/main/src/javascript-node
 
-# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
-ARG VARIANT="16-bullseye"
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+# [Choice] Node.js version (use -bookworm variants on local arm64/Apple Silicon): 24, 22, 24-bookworm, 22-bookworm, 24-bullseye, 22-bullseye
+ARG VARIANT="24-bookworm"
+FROM mcr.microsoft.com/devcontainers/javascript-node:1-${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,10 +5,10 @@
 	"runArgs": ["--init"],
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick a Node version: 16, 14, 12.
-		// Append -bullseye or -buster to pin to an OS version.
-		// Use -bullseye variants on local arm64/Apple Silicon.
-		"args": { "VARIANT": "14" }
+		// Update 'VARIANT' to pick a Node version: 24, 22.
+		// Append -bookworm or -bullseye to pin to an OS version.
+		// Use -bookworm variants on local arm64/Apple Silicon.
+		"args": { "VARIANT": "24-bookworm" }
 	},
 
 	// Set *default* container specific settings.json values on container create.

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: lts/*
       - name: Install Packages
         run: npm i --legacy-peer-deps
       - name: Lint

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 24
       - name: Install Packages
         run: npm i --legacy-peer-deps
       - name: Lint
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [22.x, 24.x]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "24"
+          node-version: lts/*
       - name: Install Dependencies
         run: npm i --legacy-peer-deps
       - name: Create Release Pull Request or Publish to npm

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ If you use this config in your Stylelint config, HTML, XML, [Vue], [Svelte], [As
 >
 > - [Stylelint] v14.0.0 and above  
 >   This config cannot be used with Stylelint v13 and below. Also, if you are using Stylelint v13, you do not need to use this config.
+> - Node.js `^22.12 || >=24`
 
 Stylelint v14 and above has been changed to not bundle non-CSS parsing such as HTML. The goal of this config is to make Stylelint v14 work with HTML (and HTML-like) files, like Stylelint v13.
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "xml.js"
   ],
   "engines": {
-    "node": "^12 || >=14"
+    "node": "^22.12 || >=24"
   },
   "scripts": {
     "test": "mocha \"tests/lib/**/*.js\" --reporter dot --timeout 60000",

--- a/tests/fixtures/integrations/stylelint/package.json
+++ b/tests/fixtures/integrations/stylelint/package.json
@@ -10,6 +10,6 @@
     "stylelint-config-recommended": "^6.0.0-0"
   },
   "engines": {
-    "node": "^12 || >=14"
+    "node": "^22.12 || >=24"
   }
 }


### PR DESCRIPTION
This drops support for Node.js versions older than 22.12, updating `engines` to `^22.12 || >=24`. Node.js 18 and 20 are already EOL, and requiring 22.12+ makes `require(esm)` available unconditionally, which the upcoming postcss-html v2 / ESM migration PRs will rely on.

The CI matrix now tests on Node.js 22 and 24, while workflow jobs that don't depend on a specific version (lint and release) use `lts/*`. The dev container has been moved from the deprecated `vscode/devcontainers` Node 14 image to `devcontainers/javascript-node` with Node 24. A major changeset is included.

This is the first of three breaking-change PRs toward v2.0.0 (followed by requiring postcss-html v2 / Stylelint v16+, and the ESM migration), so the Version Packages PR should not be merged until all of them land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)