### PR TITLE
Require postcss-html v2 and Stylelint v16+

### DIFF
--- a/.changeset/require-postcss-html-v2.md
+++ b/.changeset/require-postcss-html-v2.md
@@ -1,0 +1,5 @@
+---
+"stylelint-config-html": major
+---
+
+Update peer dependencies: `postcss-html` now requires `^2.0.0`, and `stylelint` now requires `>=16.0.0`.

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: lts/*
       - name: Install Packages
-        run: npm i --legacy-peer-deps
+        run: npm i
       - name: Lint
         run: npm run lint
   test:
@@ -30,6 +30,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Packages
-        run: npm i --legacy-peer-deps
+        run: npm i
       - name: Test
         run: npm test

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: lts/*
       - name: Install Dependencies
-        run: npm i --legacy-peer-deps
+        run: npm i
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ If you use this config in your Stylelint config, HTML, XML, [Vue], [Svelte], [As
 
 > **Requirements**
 >
-> - [Stylelint] v14.0.0 and above  
->   This config cannot be used with Stylelint v13 and below. Also, if you are using Stylelint v13, you do not need to use this config.
+> - [Stylelint] v16.0.0 and above
+> - [postcss-html](https://github.com/ota-meshi/postcss-html) v2.0.0 and above
 > - Node.js `^22.12 || >=24`
 
-Stylelint v14 and above has been changed to not bundle non-CSS parsing such as HTML. The goal of this config is to make Stylelint v14 work with HTML (and HTML-like) files, like Stylelint v13.
+Stylelint v14 and above has been changed to not bundle non-CSS parsing such as HTML. The goal of this config is to make Stylelint work with HTML (and HTML-like) files, like Stylelint v13.
 
 To see this config, please read the [config itself](/index.js).
 

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "changeset:publish": "changeset publish"
   },
   "peerDependencies": {
-    "postcss-html": "^1.0.0",
-    "stylelint": ">=14.0.0"
+    "postcss-html": "^2.0.0",
+    "stylelint": ">=16.0.0"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",

--- a/tests/fixtures/integrations/stylelint/package.json
+++ b/tests/fixtures/integrations/stylelint/package.json
@@ -4,10 +4,10 @@
   "version": "1.0.0",
   "description": "",
   "devDependencies": {
-    "postcss-html": "^1.5.0",
-    "stylelint": "^14.0.0-0",
+    "postcss-html": "^2.0.0",
+    "stylelint": "^16.0.0 || ^17.0.0",
     "stylelint-config-html": "file:../../../../",
-    "stylelint-config-recommended": "^6.0.0-0"
+    "stylelint-config-recommended": "^18.0.0"
   },
   "engines": {
     "node": "^22.12 || >=24"

--- a/tests/fixtures/integrations/stylelint/src/invalid.xml
+++ b/tests/fixtures/integrations/stylelint/src/invalid.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .a {
+      color: red;
+    }
+    .b {
+      color: #00;
+    }
+  </style>
+</svg>

--- a/tests/fixtures/integrations/stylelint/src/valid.xml
+++ b/tests/fixtures/integrations/stylelint/src/valid.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .a {
+      color: red;
+    }
+    .b {
+      color: blue;
+    }
+  </style>
+</svg>

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -12,7 +12,7 @@ describe("Integration with stylelint", () => {
   before(() => {
     originalCwd = process.cwd();
     process.chdir(path.join(__dirname, "../fixtures/integrations/stylelint"));
-    cp.execSync("npm i --no-package-lock --legacy-peer-deps", {
+    cp.execSync("npm i --no-package-lock", {
       stdio: "inherit",
     });
   });
@@ -34,6 +34,9 @@ describe("Integration with stylelint", () => {
   });
   it("should lint without errors with php", () => {
     cp.execSync(`${STYLELINT} src/valid.php`, { stdio: "inherit" });
+  });
+  it("should lint without errors with xml", () => {
+    cp.execSync(`${STYLELINT} src/valid.xml`, { stdio: "inherit" });
   });
   it("should lint with errors with html", () => {
     try {
@@ -62,6 +65,14 @@ describe("Integration with stylelint", () => {
   it("should lint with errors with astro", () => {
     try {
       cp.execSync(`${STYLELINT} src/invalid.astro`, { stdio: "inherit" });
+      fail("Expect an error, but without errors");
+    } catch {
+      // Expected!
+    }
+  });
+  it("should lint with errors with xml", () => {
+    try {
+      cp.execSync(`${STYLELINT} src/invalid.xml`, { stdio: "inherit" });
       fail("Expect an error, but without errors");
     } catch {
       // Expected!


### PR DESCRIPTION
This updates the peer dependencies to `postcss-html@^2.0.0` and `stylelint@>=16.0.0`, with a major changeset. postcss-html v2 is ESM-only, and Stylelint v16 is the first version that can `import()` an ESM custom syntax, which is why the Stylelint floor moves together with it.

The integration test fixture now installs postcss-html v2 with `stylelint@^16.0.0 || ^17.0.0` and `stylelint-config-recommended@^18.0.0`, and gains XML fixtures (`valid.xml` / `invalid.xml`), which were previously untested. I also verified the exact lower bound locally: with `stylelint@16.0.0` + `postcss-html@2.0.0` + `stylelint-config-recommended@14.0.0`, all six syntaxes (HTML, Vue, Svelte, Astro, PHP, XML) lint correctly and invalid files produce genuine rule errors rather than crashes.

Since the peer ranges now resolve cleanly, `--legacy-peer-deps` has been removed from the workflows and the fixture install.

This is the second of three breaking-change PRs toward v2.0.0 (after #62, before the ESM migration). The Version Packages PR should not be merged until all of them land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)