### PR TITLE
Set changesets access to public to fix npm publish

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,7 +9,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []


### PR DESCRIPTION
The v2.0.0 release failed with `EUNSCOPED Can't restrict access to unscoped packages`: `.changeset/config.json` had `"access": "restricted"`, which `changeset publish` passes through to `npm publish`, and npm only allows restricted access for scoped packages. Setting it to `"public"` fixes this.

Merging this will re-trigger the Release workflow, which should detect that 2.0.0 is still unpublished and retry the publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)