### PR TITLE
Fix changesets action v2 inputs

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -35,7 +35,7 @@ jobs:
         id: changesets
         uses: changesets/action@v2.0.0
         with:
-          version: npm run changeset:version
-          publish: npm run changeset:publish
+          version-script: npm run changeset:version
+          publish-script: npm run changeset:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Changesets action v2 rejects the legacy `version` and `publish` inputs, which caused the Release workflow to fail immediately after the action upgrade.

This renames those inputs to `version-script` and `publish-script` while preserving the existing npm commands. It restores the release workflow without changing publishing behavior.

Fixes the failure in [run 31646158194](https://github.com/ota-meshi/stylelint-config-html/actions/runs/31646158194).
